### PR TITLE
Fix #186 parse error due to tab in git config file

### DIFF
--- a/python/Lib/ConfigParser.py
+++ b/python/Lib/ConfigParser.py
@@ -436,6 +436,7 @@ class RawConfigParser:
         r'\]'                                 # ]
         )
     OPTCRE = re.compile(
+        r'\s*'                                # ignore any starting white space
         r'(?P<option>[^:=\s][^:=]*)'          # very permissive!
         r'\s*(?P<vi>[:=])\s*'                 # any number of space/tab,
                                               # followed by separator
@@ -444,6 +445,7 @@ class RawConfigParser:
         r'(?P<value>.*)$'                     # everything up to eol
         )
     OPTCRE_NV = re.compile(
+        r'\s*'                                # ignore any starting white space
         r'(?P<option>[^:=\s][^:=]*)'          # very permissive!
         r'\s*(?:'                             # any number of space/tab,
         r'(?P<vi>[:=])\s*'                    # optionally followed by

--- a/python/Lib/ConfigParser.py
+++ b/python/Lib/ConfigParser.py
@@ -436,7 +436,7 @@ class RawConfigParser:
         r'\]'                                 # ]
         )
     OPTCRE = re.compile(
-        r'\s*'                                # ignore any starting white space
+        r'[ \t]*'                             # ignore any starting white space
         r'(?P<option>[^:=\s][^:=]*)'          # very permissive!
         r'\s*(?P<vi>[:=])\s*'                 # any number of space/tab,
                                               # followed by separator
@@ -445,7 +445,7 @@ class RawConfigParser:
         r'(?P<value>.*)$'                     # everything up to eol
         )
     OPTCRE_NV = re.compile(
-        r'\s*'                                # ignore any starting white space
+        r'[ \t]*'                             # ignore any starting white space
         r'(?P<option>[^:=\s][^:=]*)'          # very permissive!
         r'\s*(?:'                             # any number of space/tab,
         r'(?P<vi>[:=])\s*'                    # optionally followed by


### PR DESCRIPTION
Fixed by allowing white space at the start of the item lines in git config file